### PR TITLE
RELEASE 2026-02-21

### DIFF
--- a/src/apps/ideology/models/completed_answer.py
+++ b/src/apps/ideology/models/completed_answer.py
@@ -69,14 +69,17 @@ class CompletedAnswer(TimeStampedUUIDModel):
             if not clean_uuid or clean_uuid not in hierarchy_map:
                 continue
 
+            margin_left = axis.get("margin_left")
+            margin_right = axis.get("margin_right")
+
             mapped_axes[clean_uuid] = format_mapped_item(
                 item_type="axis",
                 value=axis.get("value"),
                 complexity_uuid=hierarchy_map[clean_uuid]["complexity_uuid"],
                 is_indifferent=axis.get("is_indifferent", False),
                 section_uuid=hierarchy_map[clean_uuid]["section_uuid"],
-                margin_left=axis.get("margin_left", 0),
-                margin_right=axis.get("margin_right", 0),
+                margin_left=margin_left if margin_left is not None else 0,
+                margin_right=margin_right if margin_right is not None else 0,
             )
         return mapped_axes
 

--- a/src/backend/settings/base.py
+++ b/src/backend/settings/base.py
@@ -131,7 +131,7 @@ DATABASES = {
         "PASSWORD": env("POSTGRES_PASSWORD", default=""),
         "HOST": env("POSTGRES_HOST", default="postgres"),
         "PORT": env("POSTGRES_PORT", default=""),
-        "CONN_MAX_AGE": env.int("CONN_MAX_AGE", default=1000),
+        "CONN_MAX_AGE": env.int("CONN_MAX_AGE", default=0),
         "DISABLE_SERVER_SIDE_CURSORS": True,
         "TEST": {
             "NAME": "testing_database",


### PR DESCRIPTION
## Type of Change
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🧹 Chore (technical task, refactoring, maintenance)

## Description
Briefly describe the changes made in this Pull Request. Explain the solution and the reasoning.
This PR fixes `Internal Server Error`s occurring on the `/api/answers/completed/.../affinity/` endpoints.
The errors were caused by explicitly null JSON values for margin inputs crashing Pydantic validations during compatibility calculations. The changes gracefully fallback to `0` when encountering these cases during `_map_axes`.
 
## Related Issue
Closes # 

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes.
- [x] Unit Tests
- [x] Manual Testing

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

## Type of Change
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🧹 Chore (technical task, refactoring, maintenance)

## Description
Briefly describe the changes made in this Pull Request. Explain the solution and the reasoning.

## Related Issue
Closes # (Link the issue here, e.g., #123)

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes.
- [ ] Unit Tests
- [ ] Manual Testing

## Checklist
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
